### PR TITLE
Add basic card search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 
 - Query-Parameter `q` legt den Suchbegriff fest
 - Optionaler Query-Parameter `lang` bestimmt Sprache von Text und Bild (Standard: `de`)
-- Optionaler Query-Parameter `fields` schränkt die Suche auf bestimmte Felder ein (`name`, `abilities`, `attacks`)
 - **Antwort:** Array mit Karten, die den Suchbegriff enthalten
 
 **Beispiel:**
-`GET /cards/search?q=Gift&fields=name,attacks&lang=de`
+`GET /cards/search?q=Gift&lang=de`
 
 ---
 
@@ -171,4 +170,4 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 
 ---
 
-**Letztes Update:** 2025-06-08
+**Letztes Update:** 2025-06-22


### PR DESCRIPTION
## Summary
- implement `/cards/search` for basic term search
- document the endpoint in the README

## Testing
- `python -m py_compile main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68586c7a98a0832fa05120ab04d832ae