### PR TITLE
Update README with local setup tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
    ```bash
    pip install -r requirements.txt
    ```
+   **Hinweis:** Führe diesen Schritt unbedingt vor dem Start von `uvicorn` aus,
+   um Fehler wie `ModuleNotFoundError: requests` zu vermeiden.
 3. API lokal starten
    ```bash
    uvicorn main:app --reload


### PR DESCRIPTION
## Summary
- note that installing dependencies with `pip install -r requirements.txt` is required before starting `uvicorn`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68587ad01ed8832f9a3b9627e9872b95