### PR TITLE
Add pytest setup and basic endpoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
    ```bash
    uvicorn main:app --reload
    ```
+4. Tests ausführen
+   ```bash
+   pytest
+   ```
 
 ---
 ## Endpunkte

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_cards_returns_list():
+    response = client.get("/cards")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_sets_returns_list():
+    response = client.get("/sets")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_events_returns_list():
+    response = client.get("/events")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_tournaments_returns_list():
+    response = client.get("/tournaments")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)


### PR DESCRIPTION
## Summary
- add pytest-based tests for main endpoints
- document test execution in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685881ed8a78832fad5115cffa5406dc