### PR TITLE
Fix image fallback in /cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
   - `weakness` – Schwäche-Typ der Karte
   - `limit` & `offset` – Pagination der Ergebnisse
 - Ohne Angabe wird nur Deutsch zurückgegeben.
+  Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es
+  existiert; andernfalls liefert die API `low.webp`.
 
 **Beispiele (DE/EN):**
 `https://ptcgp-api-production.up.railway.app/cards?set_id=A2a&type=Metal&limit=10`

--- a/main.py
+++ b/main.py
@@ -196,7 +196,7 @@ def get_cards(
 
         c = card.copy()
         c["set"] = _sets.get(c["set_id"])
-        c["image"] = f"https://assets.tcgdex.net/{lang}/tcgp/{c['set_id']}/{c['_local_id']}/high.webp"
+        c["image"] = _image_url(lang, c["set_id"], c["_local_id"])
         del c["_local_id"]
         result.append(_filter_language(c, lang))
 


### PR DESCRIPTION
## Summary
- call `_image_url()` from `get_cards`
- describe image fallback in README

## Testing
- `python3 -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_685881ec0930832faaddda37edfb537a