### PR TITLE
Update requirements with httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn[standard]
 requests
+httpx>=0.27,<0.28


### PR DESCRIPTION
## Summary
- add `httpx` to requirements so the API can call HTTP services

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858fbb9c698832f8427d8d0940267fd