### PR TITLE
Add extended API test coverage

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import pytest
+import requests
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -8,22 +10,107 @@ from main import app
 
 client = TestClient(app)
 
+
+@pytest.fixture(autouse=True)
+def disable_network(monkeypatch):
+    """Avoid real network calls during tests."""
+    def fake_image_url(lang: str, set_id: str, local_id: str) -> str:
+        return f"/mock/{lang}/{set_id}/{local_id}.webp"
+
+    class DummyResp:
+        status_code = 200
+
+    monkeypatch.setattr("main._image_url", fake_image_url)
+    monkeypatch.setattr(requests, "head", lambda *a, **k: DummyResp())
+
+
 def test_cards_returns_list():
     response = client.get("/cards")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
 
 def test_sets_returns_list():
     response = client.get("/sets")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
+
 def test_events_returns_list():
     response = client.get("/events")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
+
 def test_tournaments_returns_list():
     response = client.get("/tournaments")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+def test_get_card_by_id():
+    response = client.get("/cards/001")
+    assert response.status_code == 200
+    assert response.json()["id"] == "001"
+
+
+def test_search_cards():
+    response = client.get("/cards/search", params={"q": "Arceus", "fields": "name"})
+    assert response.status_code == 200
+    data = response.json()
+    assert any(card["id"] == "001" for card in data)
+
+
+def test_user_endpoints():
+    user = "alice"
+    have_cards = ["001"]
+    want_cards = ["002"]
+
+    resp = client.post(f"/users/{user}/have", json=have_cards)
+    assert resp.status_code == 200
+
+    resp = client.post(f"/users/{user}/want", json=want_cards)
+    assert resp.status_code == 200
+
+    resp = client.get(f"/users/{user}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["have"] == have_cards
+    assert data["want"] == want_cards
+
+
+def test_deck_and_group_flow():
+    # create deck
+    resp = client.post("/decks", params={"name": "Test Deck"}, json=["001"])
+    assert resp.status_code == 200
+    deck = resp.json()
+    deck_id = deck["id"]
+
+    # list decks
+    resp = client.get("/decks")
+    assert resp.status_code == 200
+    assert any(d["id"] == deck_id for d in resp.json())
+
+    # get deck
+    resp = client.get(f"/decks/{deck_id}")
+    assert resp.status_code == 200
+
+    # vote deck
+    resp = client.post(f"/decks/{deck_id}/vote", params={"vote": "up"})
+    assert resp.status_code == 200
+    assert resp.json()["votes"] == 1
+
+    # create group
+    resp = client.post("/groups", params={"name": "Test Group"})
+    assert resp.status_code == 200
+    group = resp.json()
+    group_id = group["id"]
+
+    user = "bob"
+    resp = client.post(f"/groups/{group_id}/join", params={"user_id": user})
+    assert resp.status_code == 200
+    assert user in resp.json()["members"]
+
+    resp = client.get(f"/groups/{group_id}")
+    assert resp.status_code == 200
+    assert user in resp.json()["members"]


### PR DESCRIPTION
## Summary
- extend API tests to cover card search, user flows, decks and groups
- ensure tests run offline by mocking image lookups

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858fbc9a8e8832faa2d3bfce3334eb4