### PR TITLE
Fix assertion in get_card_by_id test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,7 +55,8 @@ def test_tournaments_returns_list():
 def test_get_card_by_id():
     resp = client.get("/cards/001")
     assert resp.status_code == 200
-    assert resp.json().get("id") == "001"
+    data = resp.json()
+    assert data.get("id") == "001"
 
 
 def test_search_cards():


### PR DESCRIPTION
## Summary
- use local `resp` variable when asserting card ID in the tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685920e9814c832fa2c7635168e240cb