### PR TITLE
Update image check with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
    pytest
    ```
 5. Optional kann die Umgebungsvariable `SKIP_IMAGE_CHECKS=1` gesetzt werden,
-   um die Prüfung von Bild-URLs (HTTP-HEAD) zu überspringen.
+   um die Prüfung von Bild-URLs (HTTP-HEAD, Timeout 3&nbsp;s) zu überspringen.
 
 ---
 ## Endpunkte
@@ -64,6 +64,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Ohne Angabe wird nur Deutsch zurückgegeben.
   Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es
   existiert; andernfalls liefert die API `low.webp`.
+  Die Prüfung erfolgt per HTTP-HEAD mit einem Timeout von 3&nbsp;Sekunden.
   Setze `SKIP_IMAGE_CHECKS`, um diese Prüfung zu deaktivieren und immer
   `high.webp` zu erhalten.
 
@@ -83,6 +84,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Ohne Angabe wird nur Deutsch ausgegeben.
 - Beispiel für Englisch: `/cards/{card_id}?lang=en`
 - Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es existiert.
+  Die Prüfung erfolgt per HTTP-HEAD mit einem Timeout von 3&nbsp;Sekunden.
   Das Ergebnis der ersten Prüfung wird zwischengespeichert, um weitere Anfragen
   schneller zu beantworten.
 

--- a/main.py
+++ b/main.py
@@ -123,15 +123,21 @@ _search_index = _build_search_index(_cards)
 
 
 def _image_url(lang: str, set_id: str, local_id: str) -> str:
+    """Return the best available image URL for a card.
+
+    Performs an HTTP ``HEAD`` request with a 3 second timeout to check for the
+    existence of the high resolution image unless ``SKIP_IMAGE_CHECKS`` is set.
+    """
+
     base = f"https://assets.tcgdex.net/{lang}/tcgp/{set_id}/{local_id}"
     high = f"{base}/high.webp"
     if os.getenv("SKIP_IMAGE_CHECKS"):
         return high
     if high not in _image_cache:
         try:
-            resp = requests.head(high)
+            resp = requests.head(high, timeout=3)
             _image_cache[high] = resp.status_code == 200
-        except Exception:
+        except requests.RequestException:
             _image_cache[high] = False
     if _image_cache[high]:
         return high


### PR DESCRIPTION
## Summary
- check high-resolution card images using a 3s timeout
- mention timeout in README documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685920f4c3f8832fa582cf3be51ef352