### PR TITLE
Introduce typed request models

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,14 @@ eine ID-Anfrage reagieren kann.
 - `GET /users/{id}` – gibt die aktuellen Listen eines Nutzers zurück
 - `GET /trades/matches` – listet einfache Tauschvorschläge zwischen Nutzern
 
+**Beispiel:**
+
+```json
+{
+  "cards": ["001", "002"]
+}
+```
+
 ### Deck-Verwaltung
 
 - `POST /decks` – neues Deck anlegen (`name`, `cards`)
@@ -173,11 +181,36 @@ eine ID-Anfrage reagieren kann.
 - `GET /decks/{deck_id}` – einzelnes Deck anzeigen
 - `POST /decks/{deck_id}/vote` – Deck bewerten (`vote=up|down`)
 
+**Beispiel für POST /decks:**
+
+```json
+{
+  "name": "Test Deck",
+  "cards": ["001"]
+}
+```
+
 ### Godpack-Gruppen
 
 - `POST /groups` – neue Gruppe anlegen (`name`)
 - `POST /groups/{group_id}/join` – Gruppe beitreten (`user_id`)
 - `GET /groups/{group_id}` – Gruppendetails abrufen
+
+**Beispiel für POST /groups:**
+
+```json
+{
+  "name": "Test Group"
+}
+```
+
+**Beispiel für POST /groups/{group_id}/join:**
+
+```json
+{
+  "user_id": "alice"
+}
+```
 
 ---
 

--- a/models.py
+++ b/models.py
@@ -1,0 +1,42 @@
+from typing import List
+from pydantic import BaseModel, Field
+
+
+class CardList(BaseModel):
+    """List of card IDs."""
+
+    cards: List[str] = Field(..., example=["001", "002"])
+
+
+class DeckCreate(BaseModel):
+    """Payload for creating a deck."""
+
+    name: str = Field(..., example="My Deck")
+    cards: List[str] = Field(..., example=["001", "002"])
+
+
+class Deck(DeckCreate):
+    """Deck with ID and vote counter."""
+
+    id: str
+    votes: int
+
+
+class GroupCreate(BaseModel):
+    """Payload for creating a group."""
+
+    name: str = Field(..., example="My Group")
+
+
+class Group(BaseModel):
+    """Group representation."""
+
+    id: str
+    name: str
+    members: List[str] = Field(default_factory=list)
+
+
+class JoinGroupRequest(BaseModel):
+    """Payload for joining a group."""
+
+    user_id: str = Field(..., example="alice")


### PR DESCRIPTION
## Summary
- add `models.py` with Pydantic models
- use typed models in deck, group and user endpoints
- document request body examples in README
- test invalid input for models and update tests

## Testing
- `black --quiet .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a7fb2a80c832fadff597db50df0db