### PR TITLE
Async image fetching with cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Asynchronous image checks using `httpx.AsyncClient` with TTL cache.
+- Error logging for failed image requests.
+
+### Changed
+- Endpoints now await image URL resolution.
+- Image URL checks cached for 24 hours to improve performance.
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
    pytest
    ```
 5. Optional kann die Umgebungsvariable `SKIP_IMAGE_CHECKS=1` gesetzt werden,
-   um die Prüfung von Bild-URLs (HTTP-HEAD, Timeout 3&nbsp;s) zu überspringen.
+   um die Prüfung von Bild-URLs (asynchroner HTTP-HEAD, Timeout 3&nbsp;s,
+   zwischengespeichert für 24&nbsp;Stunden) zu überspringen.
 
 ---
 ## Endpunkte
@@ -64,7 +65,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Ohne Angabe wird nur Deutsch zurückgegeben.
   Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es
   existiert; andernfalls liefert die API `low.webp`.
-  Die Prüfung erfolgt per HTTP-HEAD mit einem Timeout von 3&nbsp;Sekunden.
+  Die Prüfung erfolgt asynchron per HTTP-HEAD mit einem Timeout von 3&nbsp;Sekunden und wird für 24&nbsp;Stunden gecacht.
   Setze `SKIP_IMAGE_CHECKS`, um diese Prüfung zu deaktivieren und immer
   `high.webp` zu erhalten.
 
@@ -84,7 +85,7 @@ Eine einfache, offene API für Pokémon TCG Pocket Kartendaten – bereitgestell
 - Ohne Angabe wird nur Deutsch ausgegeben.
 - Beispiel für Englisch: `/cards/{card_id}?lang=en`
 - Das hochauflösende Bild (`high.webp`) wird nur dann verwendet, wenn es existiert.
-  Die Prüfung erfolgt per HTTP-HEAD mit einem Timeout von 3&nbsp;Sekunden.
+  Die Prüfung erfolgt asynchron per HTTP-HEAD mit einem Timeout von 3&nbsp;Sekunden und wird für 24&nbsp;Stunden gecacht.
   Das Ergebnis der ersten Prüfung wird zwischengespeichert, um weitere Anfragen
   schneller zu beantworten.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastapi
 uvicorn[standard]
-requests
 httpx>=0.27,<0.28
+cachetools>=6,<7

--- a/tests/test_image_cache.py
+++ b/tests/test_image_cache.py
@@ -1,0 +1,48 @@
+import asyncio
+import logging
+import os
+from cachetools import TTLCache
+import httpx
+
+
+import main
+
+
+def test_image_url_cache(monkeypatch):
+    calls = []
+
+    os.environ.pop("SKIP_IMAGE_CHECKS", None)
+
+    async def dummy_head(self, url, timeout=3):
+        calls.append(url)
+
+        class R:
+            status_code = 200
+
+        return R()
+
+    monkeypatch.setattr(main, "_image_cache", TTLCache(maxsize=10, ttl=10))
+    monkeypatch.setattr(httpx.AsyncClient, "head", dummy_head)
+
+    url1 = asyncio.run(main._image_url("de", "A2a", "001"))
+    url2 = asyncio.run(main._image_url("de", "A2a", "001"))
+    assert url1 == url2
+    assert len(calls) == 1
+
+
+def test_image_url_timeout(monkeypatch, caplog):
+    os.environ.pop("SKIP_IMAGE_CHECKS", None)
+
+    async def timeout_head(self, url, timeout=3):
+        raise httpx.TimeoutException("boom")
+
+    cache = TTLCache(maxsize=10, ttl=10)
+    monkeypatch.setattr(main, "_image_cache", cache)
+    monkeypatch.setattr(httpx.AsyncClient, "head", timeout_head)
+
+    caplog.set_level(logging.ERROR)
+    url = asyncio.run(main._image_url("de", "A2a", "001"))
+    assert url.endswith("low.webp")
+    high = "https://assets.tcgdex.net/de/tcgp/A2a/001/high.webp"
+    assert cache[high] is False
+    assert any("HEAD request failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- make `_image_url` async and use `httpx.AsyncClient`
- cache image existence checks with `TTLCache`
- update card endpoints to await `_image_url`
- add structured error logging
- document new behaviour and create `CHANGELOG`
- add tests for caching and timeout handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a86ff9314832fbfbcd7970cbf008a